### PR TITLE
Update gelu.py

### DIFF
--- a/keras_transformer/gelu.py
+++ b/keras_transformer/gelu.py
@@ -7,4 +7,4 @@ def gelu(x):
 
     See: https://arxiv.org/pdf/1606.08415.pdf
     """
-    return 0.5 * x * (1.0 + K.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x * x * x)))
+    return 0.5 * x * (1.0 + K.tanh(0.7978845608028654 * (x + 0.044715 * x * x * x))) #save some ops -> math.sqrt(2.0 / math.pi) = 0.7978845608028654


### PR DESCRIPTION
replaced ´math.sqrt( 2.0 / math.pi )´ with the approximation 0.7978845608028654 to save some op/s